### PR TITLE
Update IRMA Module Output Settings and Modify Abricate_flu Module for Specific Flu B Classification

### DIFF
--- a/modules/local/abricate_flu.nf
+++ b/modules/local/abricate_flu.nf
@@ -75,9 +75,13 @@ process ABRICATE_FLU {
 
     # Find INSaFLU subtype if Type B
     if grep -q "Type_B" $abricate_type; then
-        if grep -q "Victoria" ${meta.id}_abricate_hits.tsv; then
+        # Check for Victoria with hemagglutinin or neuraminidase or both
+        if (grep -q "Victoria" ${meta.id}_abricate_hits.tsv && grep -q "hemagglutinin" ${meta.id}_abricate_hits.tsv) || \
+            (grep -q "Victoria" ${meta.id}_abricate_hits.tsv && grep -q "neuraminidase" ${meta.id}_abricate_hits.tsv); then
             echo "Victoria" > $abricate_subtype
-        elif grep -q "Yamagata" ${meta.id}_abricate_hits.tsv; then
+        # Check for Yamagata with hemagglutinin or neuraminidase or both
+        elif (grep -q "Yamagata" ${meta.id}_abricate_hits.tsv && grep -q "hemagglutinin" ${meta.id}_abricate_hits.tsv) || \
+            (grep -q "Yamagata" ${meta.id}_abricate_hits.tsv && grep -q "neuraminidase" ${meta.id}_abricate_hits.tsv); then
             echo "Yamagata" > $abricate_subtype
         else
             echo "No abricate subtype" > $abricate_subtype
@@ -114,10 +118,12 @@ process ABRICATE_FLU {
         elif grep -q "H10" ${meta.id}_abricate_hits.tsv && grep -q "N8" ${meta.id}_abricate_hits.tsv; then
             echo "H10N8" > $abricate_subtype
     # Victoria
-        elif grep -q "Victoria" ${meta.id}_abricate_hits.tsv; then
+        elif (grep -q "Victoria" ${meta.id}_abricate_hits.tsv && grep -q "hemagglutinin" ${meta.id}_abricate_hits.tsv) || \
+            (grep -q "Victoria" ${meta.id}_abricate_hits.tsv && grep -q "neuraminidase" ${meta.id}_abricate_hits.tsv); then
             echo "Victoria" > $abricate_subtype
     # Yamagata
-        elif grep -q "Yamagata" ${meta.id}_abricate_hits.tsv; then
+        elif (grep -q "Yamagata" ${meta.id}_abricate_hits.tsv && grep -q "hemagglutinin" ${meta.id}_abricate_hits.tsv) || \
+            (grep -q "Yamagata" ${meta.id}_abricate_hits.tsv && grep -q "neuraminidase" ${meta.id}_abricate_hits.tsv); then
             echo "Yamagata" > $abricate_subtype
         else
             echo "No abricate subtype" > $abricate_subtype

--- a/modules/local/irma.nf
+++ b/modules/local/irma.nf
@@ -10,8 +10,8 @@ process IRMA {
 
     output:
     tuple val(meta), path("${meta.id}/")               , emit: irma
-    tuple val(meta), path("${meta.id}/*.bam")          , emit: irma_bam
-    tuple val(meta), path("${meta.id}/*.fasta")        , emit: irma_fasta
+    tuple val(meta), path("${meta.id}/*.bam")          , optional:true, emit: irma_bam
+    tuple val(meta), path("${meta.id}/*.fasta")        , optional:true, emit: irma_fasta
     tuple val(meta), path("*.irma.consensus.fasta")    , optional:true, emit: assembly
     tuple val(meta), path("*_LOW_ABUNDANCE.txt")       , optional:true, emit: failed_assembly
     tuple val(meta), path("*_HA.fasta")                , optional:true, emit: HA


### PR DESCRIPTION
This pull request introduces two changes that improve the file outputs of the IRMA module and enhance the flu B lineage classification in the Abricate_flu module.

1. IRMA Module Output Modification: The outputs for BAM and FASTA files have been updated to optional: true. This will ensure that any absence of output BAM and/or FASTA files during IRMA module execution does not cause the process to halt or fail, addressing issues related to missing output files in certain scenarios.

2. Syntax Update for the Abricate_flu Module: Introduces a better approach to classifying flu B viruses by focusing specifically on the hemagglutinin (HA) and neuraminidase (NA) segments for flu B lineage determination. The revised code now includes a conditional logic to identify the flu B virus as either Victoria or Yamagata lineage based on the presence of HA and NA markers in the abricate output. The updated script checks for the presence of "Type_B" in the classification output and then proceeds to determine the subtype by searching for "Victoria" or "Yamagata" in conjunction with "hemagglutinin" or "neuraminidase". The logic is as follows: if either HA or NA markers, or both, are found in conjunction with "Type B" in the ${meta.id}_abricate_hits.tsv file, the script assigns the respective subtype.
This modification improves the accuracy of flu B lineage classification by relying on the HA and NA segments, which are the indicators of the flu B lineage, and addresses a previous limitation where lineage assignment might have been inaccurately influenced by non-specific markers such as matrix proteins (MP).